### PR TITLE
ci: acidential deployment to prod identified: untagged workflow over…

### DIFF
--- a/.github/workflows/backendAPI.yml
+++ b/.github/workflows/backendAPI.yml
@@ -250,6 +250,10 @@ jobs:
           docker push \
               ${{env.REGISTRY}}/${{github.repository}}-backend_api:$COMMIT_SHA
 
+  # TBD: Fix: The untagged action run after the infrastructure workflow run
+  # is updating the latest tagged image in github container registry,
+  # which then gets used in prod - even though the workflow only ran in stage
+  # That is basically the unwanted deployment to prod!
   deploy_stage:
     needs: containerize
     # if: ${{ github.event.ref == 'refs/heads/main' || github.event.ref == 'refs/heads/stage' }}

--- a/scripts/deploy_infrastructure.sh
+++ b/scripts/deploy_infrastructure.sh
@@ -51,8 +51,6 @@
 #         -var "azure_subscription_id=${AZURE_SUBSCRIPTION_ID}" \
 #         -reconfigure
 
-# TBD: check if this script triggers the unwanted deployment to prod?
-
 echo "=== Running: deploy_infrastructure ==="
 
 echo ""


### PR DESCRIPTION
…writes the latest tagged image with main commit sha, and then prod loads that image next time the server scales from 0 to 1

The untagged workflow run is initiated by a successful infrastructure run!