### PR TITLE
chore: upgrades ubuntu in infrastructure pipeline to version 26.04

### DIFF
--- a/.github/workflows/infrastructure.yml
+++ b/.github/workflows/infrastructure.yml
@@ -42,7 +42,7 @@ env:
 
 jobs:
   plan:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     permissions:
       id-token: write
       contents: write
@@ -245,7 +245,7 @@ jobs:
   apply:
     needs: plan
     if: ${{ needs.plan.outputs.tofu_plan_exit_code == 2 }}
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     permissions:
       id-token: write
     environment: infrastructure-apply


### PR DESCRIPTION
expected to fail frontend and backend in stage, as it's running on main's pipepline files.